### PR TITLE
Remove double negative from `ICPX` transfer `HUB -> MMU`

### DIFF
--- a/hub/instruction_handling/halt/return/generalities.tex
+++ b/hub/instruction_handling/halt/return/generalities.tex
@@ -315,11 +315,11 @@ Indeed, \textbf{the \mmuMod{} module expects small parameters}, see chapter~(\re
 			\item \If $\locCheckFirstByte = 1$
 				\[
 					\setMmuInstructionParametersInvalidCodePrefix {
-						anchorRow      = i                                        ,
-						relOffset      = \locFirstMiscRowOffset                   ,
-						sourceId       = \cn _{i}                                 ,
-						sourceOffsetLo = \locOffsetLo                             ,
-						successBit     = 1 - \stackIcpx _{i - \locStackRowOffset} ,
+						anchorRow      = i                                    ,
+						relOffset      = \locFirstMiscRowOffset               ,
+						sourceId       = \cn _{i}                             ,
+						sourceOffsetLo = \locOffsetLo                         ,
+						successBit     = \stackIcpx _{i - \locStackRowOffset} ,
 					}
 				\]
 			\item \If $\locWriteSomeReturnData = 1$

--- a/mmu/instructions/invalidCodePrefix/preprocessing.tex
+++ b/mmu/instructions/invalidCodePrefix/preprocessing.tex
@@ -35,7 +35,7 @@ This allows us to deal both with pre-processing and micro-instruction-writing fr
 		\]
 		and we further impose that
 		\[
-			\macroSuccessBit_{i} = 1 - \ppWcpRes_{i + 1}
+			\macroSuccessBit_{i} = \ppWcpRes_{i + 1}
 		\]
 		we define the following shorthands:
 		\[
@@ -65,5 +65,8 @@ This allows us to deal both with pre-processing and micro-instruction-writing fr
 		\end{array} \right.
 		\]
 \end{description}
-\saNote{} The value present in $\microLimb_{i + \nppMmuInstInvalidCodePrefixValuePO}$ will be justified in the \mmioMod{} module by the  \mmioInstRamToLimbOneSource{} instruction.
+\saNote{}
+The value present in $\microLimb_{i + \nppMmuInstInvalidCodePrefixValuePO}$
+will be justified in the \mmioMod{} module
+via the \mmioInstRamToLimbOneSource{} instruction.
 It is the byte contained at offset $\macroSrcOffsetLo_{i}$ in the \textsc{ram} of the execution context with context number $\macroSrcId_{i}$.


### PR DESCRIPTION
Implemented in https://github.com/Consensys/linea-constraints/pull/547