### PR TITLE
`undoDepStatusAndNumberUpdate` wrong constraint fix

### DIFF
--- a/hub/account/specialized_constraints/deployment.tex
+++ b/hub/account/specialized_constraints/deployment.tex
@@ -18,9 +18,8 @@ Below $\relof$ is a (small) positive integer.
 			\accUndoDeploymentStatusAndNumberUpdate {i}{\reluo}{\reldo} \iff
 			\left\{ \begin{array}{lcl}
 				\multicolumn{3}{l}{\accSameDeploymentNumber {i}{\reluo}} \\
-				\accDeploymentNumber   _{i + \reluo} & = & \accDeploymentNumber\new   _{i + \reldo} \\
-				\accDeploymentStatus          _{i + \reluo} & = & \accDeploymentStatus\new   _{i + \reldo} \\
-				\accDeploymentStatus\new      _{i + \reluo} & = & \accDeploymentStatus       _{i + \reldo} \\
+				\accDeploymentStatus      _{i + \reluo} & = & \accDeploymentStatus\new  _{i + \reldo} \\
+				\accDeploymentStatus\new  _{i + \reluo} & = & \accDeploymentStatus      _{i + \reldo} \\
 			\end{array} \right. } \\
 	\end{array} \right.
 \]


### PR DESCRIPTION
We _can't_ connect the deployment statuses, that was a mistake. E.g. consider the case where you
- precompute deployment address `dep_addr`
- perform an `EXTCODEHASH` or `EXTCODESIZE` on `dep_addr`
- then perform the relevant CREATE to bring the `dep_addr` into existence
- finish on a `REVERT`

In this case the undoing deployment number is += 1 rel to the one encountered when initially tracing the `EXTCODEXXX` opcode.

**N.B.** This fixes the java test `extcodexxxBeforeDuringAndAfterDeploymentDeployingEmtpyByteCode`

Implementation PR:
- https://github.com/Consensys/linea-constraints/pull/551