### PR TITLE
`EXTCODECOPY` requires the `CFI` as its `MMU_SRC_ID` only for addresses not currently under deployment

### DIFF
--- a/hub/instruction_handling/copy/generalities.tex
+++ b/hub/instruction_handling/copy/generalities.tex
@@ -249,9 +249,9 @@ The constraints are as follows:
 						we impose
 						\[
 							\left\{ \begin{array}{lcl}
-								\locSourceId        & \define & \locForeignAddressCfi                                      \\
+								\locSourceId        & \define & \locForeignAddressHasCode \cdot \locForeignAddressCfi      \\
 								\locReferenceOffset & \define & 0                                                          \\
-								\locReferenceSize   & \define & \locForeignAddressCodeSize \cdot \locForeignAddressHasCode \\
+								\locReferenceSize   & \define & \locForeignAddressHasCode \cdot \locForeignAddressCodeSize \\
 								\locExoSum          & \define & \exoWeightRom                                              \\
 							\end{array} \right.
 						\]


### PR DESCRIPTION
Addresses an issue where nontrivial invocations of `EXTCODECOPY` at addresses currently undergoing deployment were providing the `MMU` module with
- for its `MMU_SRC_ID`: the init code's `CODE_FRAGMENT_INDEX`
- for its `MMU_REF_SIZE`: 0

Now we provide 0 to both `MMU_SRC_ID` and `MMU_REF_SIZE` in such cases.

Implemented in https://github.com/Consensys/linea-constraints/pull/554