### PR TITLE
chore: fixed typo in variable name

### DIFF
--- a/formal/annotations.tex
+++ b/formal/annotations.tex
@@ -1,4 +1,4 @@
-\textbf{Annotations} already exist in \corset{} e.g. for types. These may serve different purposes: simplify constraint systems, provide implicit assumptions to the prover for specialized verification. See below. But we could add more annotations. For instance we could add annotations to help the transpiler to set up theorem stumps and prove intermeidary lemmas by itself:
+\textbf{Annotations} already exist in \corset{} e.g. for types. These may serve different purposes: simplify constraint systems, provide implicit assumptions to the prover for specialized verification. See below. But we could add more annotations. For instance we could add annotations to help the transpiler to set up theorem stumps and prove intermediary lemmas by itself:
 \begin{Verbatim}[commandchars=\\\{\}]
 (module toy-example)
 


### PR DESCRIPTION
I corrected a typo in the code. The word "intermeidary" was changed to the correct spelling "intermediary". 