### PR TITLE
fix: remove offset from `ct_max_sum` when setting `(next CT_MAX)` from a scenario row

### DIFF
--- a/mxp_v3/generalities/heartbeat.tex
+++ b/mxp_v3/generalities/heartbeat.tex
@@ -36,7 +36,7 @@ $\mxpStamp _{i + 1} \in \{ \mxpStamp _{i}, 1 + \mxpStamp _{i} \}$ at all times.
 			\end{array} \right.
 		\]
 	\item \If $\isMxpInstructionDecoder _{i} + \isMxpMacro _{i} + \isMxpScenario _{i} = 1$ \Then $\maxCt_{i} = 0$
-	\item \If $\isMxpScenario _{i} = 1$ \Then $\maxCt_{i + 1} = \locCtMaxSum _{i + 1}$
+	\item \If $\isMxpScenario _{i} = 1$ \Then $\maxCt_{i + 1} = \locCtMaxSum _{i}$
 	\item we unconditionally impose
 		\[
 			\left[ \begin{array}{lrclclclcr}


### PR DESCRIPTION
## Issue

`ct_max_sum` only makes sense along `SCENARIO` rows
<img width="1061" height="236" alt="image" src="https://github.com/user-attachments/assets/d31ea163-a800-4782-afe9-5e21414f0119" />
which makes the following constraint incorrect
<img width="646" height="72" alt="image" src="https://github.com/user-attachments/assets/d40df59e-4601-4b7f-9994-f05062b04cbe" />

## Fix

Change the CT_MAX setting constraint to use the non shifted value of the shorthand `ct_max_sum`:
<img width="646" height="72" alt="image" src="https://github.com/user-attachments/assets/4aba4c68-b8de-48d4-9932-df507774d76c" />
