### PR TITLE
Fix Typo in Makefile Targets for "log_data" and "log_info"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ hash_data:       view-hash_data
 hash_info:       view-hash_info
 hub:             view-hub
 lex:             view-lex
-logd_data:       view-log_data
-logi_info:       view-log_info
+log_data:        view-log_data
+log_info:        view-log_info
 mmio:            view-mmio
 modexp:          view-modexp_data
 mmu:             view-mmu


### PR DESCRIPTION
## Description

This PR corrects **typographical errors** in the `Makefile` that prevented the `log_data` and `log_info` targets from invoking the appropriate build rules.

### Changes Made:
- Fixed incorrect target or variable names in the `Makefile` for `log_data` and `log_info`.
- Ensured both targets now point to the correct build steps.