### PR TITLE
Fix Makefile Targets for "log_data" and "log_info"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ hash_data:       view-hash_data
 hash_info:       view-hash_info
 hub:             view-hub
 lex:             view-lex
-logd_data:       view-log_data
-logi_info:       view-log_info
+log_data:        view-log_data
+log_info:        view-log_info
 mmio:            view-mmio
 modexp:          view-modexp_data
 mmu:             view-mmu


### PR DESCRIPTION
## Description

This PR fixes `small typos` in the **Makefile** that were causing the `log_data` and `log_info` targets to break. The issue was that they weren’t pointing to the right build rules due to incorrect variable names.

### Changes Made:
- Corrected the target definitions for `log_data` and `log_info`
- Both now properly trigger their intended build logic