### PR TITLE
EIP-7823: set upper bounds for `MODEXP` (`MMU` side)

### DIFF
--- a/mmio/lookups/mmio_into_shakira_for_keccak.tex
+++ b/mmio/lookups/mmio_into_shakira_for_keccak.tex
@@ -15,7 +15,7 @@ The lookup to the \shakiraMod{} is constructed as follows:
 		\end{multicols}
 		\saNote{}
 		We provide the ``phase'' value manually.
-	\item[\underline{Target columns:}] from the \shakiraMod{} module: 
+	\item[\underline{Target columns:}] from the \shakiraMod{} module:
 		\begin{multicols}{3}
 			\begin{enumerate}
 				\item $\shakiraId_{j}$
@@ -29,9 +29,9 @@ The lookup to the \shakiraMod{} is constructed as follows:
 		\end{multicols}
 \end{description}
 
-\saNote{} There are three different \hubMod{} instructions triggering the present lookup: 
+\saNote{} There are three different \hubMod{} instructions triggering the present lookup:
 (\emph{a}) \inst{SHA3} when hashing a (nonempty) slice of bytes,
 (\emph{b}) \inst{RETURN} when (temporarily) deploying (nonempty) bytecode,
 (\emph{c}) \inst{CREATE2} when hashing (nonempty) initialization code.
 All three of which enter the \mmuMod{} by means of a \mmuInstRamToExoWithPadding{} instruction.
-Inspecting the \hubMod{} / \mmuMod{} interface, see section~(\ref{mmu: hub / mmu interface}), one notices that no \macroPhase{} is provided by said instruction, yet the \shakiraMod{} requires a phase and hence the lookup requires one too. This phase is provided in the above. 
+Inspecting the \hubMod{} / \mmuMod{} interface, see section~(\ref{mmu: hub <> mmu interface}), one notices that no \macroPhase{} is provided by said instruction, yet the \shakiraMod{} requires a phase and hence the lookup requires one too. This phase is provided in the above.

--- a/mmu/_all_mmu.tex
+++ b/mmu/_all_mmu.tex
@@ -2,7 +2,7 @@
 \usepackage[dvipsnames]{xcolor}
 \usepackage{fontspec}
 \usepackage{../pkg/common}
-% \usepackage{../pkg/dark_theme}
+\usepackage{../pkg/constants/eip-7823_MODEXP_limits}
 \usepackage{../pkg/std}
 \usepackage{../pkg/IEEEtrantools}
 \usepackage{../pkg/env}

--- a/mmu/instructions/modexpData/intro.tex
+++ b/mmu/instructions/modexpData/intro.tex
@@ -37,7 +37,8 @@ What follows is, depending on the case, the desired interpretation of some of th
 Using shorthands introduced in section~(\ref{mmu: instructions: modexpdata: shorthands}) we will furthermore be guaranteed that
 \[
 	\left\{ \begin{array}{l}
-		0 < \locModexpParamByteSize \leq 512    \\
-		0 < \locModexpParamOffset        \ll 256^4 \\
+		0 < \locModexpParamByteSize \leq \modexpMaxByteSizeName             \\
+		\modexpMaxByteSizeName \define \modexpMaxByteSizeValue \vspace{2mm} \\
+		0 < \locModexpParamOffset   <    \mxpxThreshold                     \\
 	\end{array} \right.
 \]

--- a/mmu/instructions/modexpData/micro_instruction_writing.tex
+++ b/mmu/instructions/modexpData/micro_instruction_writing.tex
@@ -5,13 +5,18 @@ We impose the following:
 	\item[\underline{Progression:}] \label{mmu: instructions: modexpdata: micro instruction writing: tlo progression}
 		we impose generally \If $\isMicro_{i} = 1$ \Then $\stdProgression_{i}\Big[\isMicro, \microTlo \Big]$
 \end{description}
-\saNote{} \label{mmu: modexData: microTLO explanation} Recall that in the present case (\mmuInstFlagModexpData{} instruction) the we have
-initially\footnote{i.e. during the pre-processing phase} $\ppTot \equiv 32$,
-see~(\ref{mmu: instructions: modexpdata: preprocessing: tot = 32 initially}),
+\saNote{} \label{mmu: modexData: microTLO explanation}
+Recall that in the present case (\mmuInstFlagModexpData{} instruction) the we have
+initially\footnote{i.e. during the pre-processing phase} $\ppTot \equiv \numberOfLimbsForModexpArgumentsAndResult$,
+see~(\ref{mmu: instructions: modexpdata: preprocessing: tot equals 64 initially}),
 and intially\footnote{i.e. on the first micro-instruction-writing row}, again, $\microTlo \equiv 0$,
 see~(\ref{mmu: instructions: modexpdata: initialize: tlo is initially 0}).
-The above therefore enforces that \microTlo{} will count monotonically and without gaps from $0$ to $31$ during the micro-instruction-writing phase.
-And indeed the goal of the present \mmuMod{}-instruction is to copy over up to $512 = 32 \times \llarge$ (potentially left and/or right zero padded) bytes of data i.e. $32$ data limbs.
+The above therefore enforces that \microTlo{} will count monotonically,
+and without gaps, from $0$ to $\numberOfLimbsForModexpArgumentsAndResult - 1$
+during the micro-instruction-writing phase.
+And indeed the goal of the present \mmuMod{}-instruction is to copy up to
+$\modexpMaxByteSizeValue = \numberOfLimbsForModexpArgumentsAndResult \times \llarge$,
+potentially left and/or right zero padded, bytes of data i.e. $\numberOfLimbsForModexpArgumentsAndResult$ data limbs.
 \begin{description}
 	\item[\underline{Zero padding rows:}] 
 		\If $\isZero_{i} = 1$ \Then

--- a/mmu/instructions/modexpData/preprocessing.tex
+++ b/mmu/instructions/modexpData/preprocessing.tex
@@ -11,12 +11,12 @@ We outline the preprocessing rows
 \begin{description}
 	\item[\underline{Admissible phases:}]
 		we impose that $\locPhase \in \{ \phaseModexpBase, \phaseModexpExponent, \phaseModexpModulus \}$ (\trash).
-	\item[\underline{Number of preprocessing rows:}] \label{mmu: instructions: modexpdata: preprocessing: tot = 32 initially}
-		we impose $\ppTot_{i} = 32$;
+	\item[\underline{Number of preprocessing rows:}] \label{mmu: instructions: modexpdata: preprocessing: tot equals 64 initially}
+		we impose $\ppTot_{i} = \numberOfLimbsForModexpArgumentsAndResult$;
 	\item[\underline{Preprocessing row $\bm{n^\circ 1}$:}] 
 		we define the following shorthand
 		\[
-			\locNleftPaddingBytes \define 512 - \locModexpParamByteSize
+			\locNleftPaddingBytes \define \modexpMaxByteSizeValue - \locModexpParamByteSize
 		\]
 		and we impose that
 		\[
@@ -58,7 +58,7 @@ We outline the preprocessing rows
 		\[
 			\left\{ \begin{array}{lclr}
 			        \ppTotRZ  _{i}   & =       & \ppEucQuot _{i + 2} \\
-			        \ppTotNT  _{i}   & =       & 32 - \ppTotLZ_{i} - \ppTotRZ_{i} & (\trash) \\
+			        \ppTotNT  _{i}   & =       & \numberOfLimbsForModexpArgumentsAndResult - \ppTotLZ_{i} - \ppTotRZ_{i} & (\trash) \\
 			\end{array} \right.
 		\]
 		(the second constraint is an implicit consequence of others and need not be implemented);

--- a/mmu/instructions/modexpZero/preprocessing.tex
+++ b/mmu/instructions/modexpZero/preprocessing.tex
@@ -1,3 +1,4 @@
+\input{../prc/blkmdx/_local}
 \begin{center}
 	\boxed{%
 		\text{The pre-processing presented below assumes that }
@@ -14,11 +15,13 @@ There is no pre-processing to speak of, but we require at least one pre-processi
 		we impose
 		\[
 			\left\{ \begin{array}{lcl}
-				\ppTotLZ    _{i}     & = & 0 \\ 
-				\ppTotNT    _{i}     & = & 32 \\ 
-				\ppTotRZ    _{i}     & = & 0 \\ 
+				\ppTotLZ _{i} & = & 0                                         \\
+				\ppTotNT _{i} & = & \numberOfLimbsForModexpArgumentsAndResult \\
+				\ppTotRZ _{i} & = & 0                                         \\
 			\end{array} \right.
 		\]
 	\item[\underline{Pre-processing row $\bm{n^\circ 1}$:}] 
-		none required, we take the opportunity to kindly ask the Ethereum Foundation to kill the \instBlake{} and \instRipemd{} precompiles \faSmileO{} (maybe even \instModexp{}.) $\quad(\trash)$
+		none required;
+		we take the opportunity to kindly ask the Ethereum Foundation
+		to kill the \instBlake{} and \instRipemd{} precompiles \faSmileO{}. $\quad(\trash)$
 \end{description}

--- a/pkg/constants/eip-7823_MODEXP_limits.sty
+++ b/pkg/constants/eip-7823_MODEXP_limits.sty
@@ -1,3 +1,4 @@
 \newcommand{\modexpMaxByteSizeName}       {\numConst{EIP\_7823\_MODEXP\_UPPER\_BOUND}}
 \newcommand{\modexpMaxByteSizeValue}      {\numConst{\modexpMaxByteSizeValuePlain}}
 \newcommand{\modexpMaxByteSizeValuePlain} {1024}
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces EIP-7823 MODEXP limit constants (1024 bytes) and updates MODexp preprocessing/micro-instruction logic from fixed 32 limbs/512 bytes to parameterized limits, plus minor doc/reference tweaks.
> 
> - **Constants**:
>   - Add `pkg/constants/eip-7823_MODEXP_limits.sty` defining `\modexpMaxByteSizeName`/`\modexpMaxByteSizeValue` (= `1024`).
>   - Include constants in `mmu/_all_mmu.tex`.
> - **MMU – `modexpData`**:
>   - Replace fixed bounds `512` bytes and `32` limbs with `\modexpMaxByteSizeValue` and `\numberOfLimbsForModexpArgumentsAndResult` throughout (`intro.tex`, `preprocessing.tex`, `micro_instruction_writing.tex`).
>   - Adjust equations, labels, and derived values (left/right padding, `\ppTotNT`, limb ranges) accordingly.
> - **MMU – `modexpZero`**:
>   - Parameterize micro-row counts to use `\numberOfLimbsForModexpArgumentsAndResult` and add local include.
> - **Docs/refs**:
>   - Minor spacing/label fixes in `mmio/lookups/mmio_into_shakira_for_keccak.tex` (interface label) and formatting tidy-ups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c83fee82721fd8bd1afd60a40b3091ca7435882. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->