### PR TITLE
feat: BIN module is deprecated

### DIFF
--- a/spec/_all_spec.tex
+++ b/spec/_all_spec.tex
@@ -136,7 +136,7 @@ Nicolas Liochon
 \chapter{The \trmMod{} module \specDeprecated{}}     \label{chap: trm}             \minitoc    \subfile{../trm/_inputs}
 \iffalse                                                                                \fi    \subfile{../alu/_inputs}
 \chapter{The \eucMod{} module}                       \label{chap: euc}             \minitoc    \subfile{../euc/_inputs}
-\chapter{The \binMod{} module}                       \label{chap: bin}             \minitoc    \subfile{../bin/_inputs}
+\chapter{The \binMod{} module} \specDeprecated{}}    \label{chap: bin}             \minitoc    \subfile{../bin/_inputs}
 \chapter{The \shfMod{} module \specDeprecated{}}     \label{chap: shf}             \minitoc    \subfile{../shf/_inputs}
 \chapter{The \wcpMod{} module \specDeprecated{}}     \label{chap: wcp}             \minitoc    \subfile{../wcp/_inputs}
 \chapter{The \btcMod{} module}                       \label{chap: block data}      \minitoc    \subfile{../block_data/_inputs}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Marks the `BIN` module chapter as deprecated in `spec/_all_spec.tex`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01f69ffa2f9b36b962593993feacad98e42be582. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->