### PR TITLE
feat: get slack notif in case of spec build failure

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -32,7 +32,7 @@ jobs:
         run: make ospec
 
       - name: Failure Notification
-        if: github.ref == (failure() || cancelled())
+        if: failure() || cancelled()
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Slack failure/cancellation notifications to the spec compile workflow and pins actions/checkout to v5.
> 
> - **CI (GitHub Actions)**:
>   - **Failure notifications**: Add Slack notification step on `failure()` or `cancelled()` using `slackapi/slack-github-action` with webhook payload.
>   - **Hard pin**: Update `actions/checkout` to v5 via commit SHA in `.github/workflows/compile.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4766976ac41eedcc2fc89f56735b12093f12aae4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->