### PR TITLE
fix: add CLZ in the BIN instruction decoder table

### DIFF
--- a/hub/instruction_handling/bin.tex
+++ b/hub/instruction_handling/bin.tex
@@ -2,12 +2,13 @@
 \begin{array}{|l||c||c|c|}
 	\hline
 	\INST				& \tli	& \stackDecBinFlag	& \decFlag{1}	\\ \hline\hline
-	\inst{AND}			& \zero	& \oneCell		& \zero 		\\ \hline
-	\inst{OR}			& \zero	& \oneCell		& \zero 		\\ \hline
-	\inst{XOR}			& \zero	& \oneCell		& \zero 		\\ \hline
-	\inst{BYTE}			& \zero	& \oneCell		& \zero 		\\ \hline
-	\inst{SIGNEXTEND}	& \zero	& \oneCell		& \zero 		\\ \hline
-	\inst{NOT}			& \zero	& \oneCell		& \oneCell		\\ \hline
+	\inst{OR}			& \zero	& \oneCell			& \zero 		\\ \hline
+	\inst{AND}			& \zero	& \oneCell			& \zero 		\\ \hline
+	\inst{XOR}			& \zero	& \oneCell			& \zero 		\\ \hline
+	\inst{BYTE}			& \zero	& \oneCell			& \zero 		\\ \hline
+	\inst{SIGNEXTEND}	& \zero	& \oneCell			& \zero 		\\ \hline
+	\inst{NOT}			& \zero	& \oneCell			& \oneCell		\\ \hline
+	\inst{CLZ}			& \zero	& \oneCell			& \oneCell		\\ \hline
 \end{array}
 \]
-\saNote{} $\decFlag{1}$ singles out the only \binMod{}-instructions following the \oneOneSP{}.
+\saNote{} $\decFlag{1}$ singles out the \binMod{}-instructions following the \oneOneSP{}.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add `CLZ` to the BIN decoder table, reorder entries, and tweak the accompanying note.
> 
> - **Instruction decoder docs (`hub/instruction_handling/bin.tex`)**:
>   - **Add `CLZ`** to the BIN decoder table with `\tli=0`, `\stackDecBinFlag=1`, `\decFlag{1}=1`.
>   - Reorder existing entries (`OR`, `AND`, `XOR`, `BYTE`, `SIGNEXTEND`, `NOT`).
>   - Tweak `\saNote{}` wording (remove "only").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ecec32b1ff2200e0dc9c060fb82ee544aea1b70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->