### PR TITLE
Use correct `dup_callee_gas` shorthand in the `HUB` + some renaming

### DIFF
--- a/hub/instruction_handling/call/precompiles/_local.tex
+++ b/hub/instruction_handling/call/precompiles/_local.tex
@@ -1,6 +1,6 @@
 \def\locFlagSum                     {\loc{flag\_sum}}
 \def\locPrcCallerGas                {\loc{dup\_caller\_gas}}
-\def\locPrcCallGas                  {\loc{dup\_call\_gas}}
+\def\locPrcCalleeGas                {\loc{dup\_callee\_gas}}
 \def\locPrcCdo                      {\loc{dup\_cdo}}
 \def\locPrcCds                      {\loc{dup\_cds}}
 \def\locPrcRao                      {\loc{dup\_r@o}}

--- a/hub/instruction_handling/call/precompiles/blake/surviving.tex
+++ b/hub/instruction_handling/call/precompiles/blake/surviving.tex
@@ -48,7 +48,7 @@ We fix the behaviour of the next row, i.e. row $n^°(i + \prcBlakeSecondMiscRowO
 					\setOobInstructionBlakeParams {
 						anchorRow   = i                            ,
 						relOffset   = \prcBlakeSecondMiscRowOffset ,
-						calleeGas   = \locCalleeGas                ,
+						calleeGas   = \locPrcCalleeGas             ,
 						blakeR      = \locBlakeR                   ,
 						blakeF      = \locBlakeF                   ,
 					}

--- a/hub/instruction_handling/call/precompiles/common/generalities.tex
+++ b/hub/instruction_handling/call/precompiles/common/generalities.tex
@@ -66,7 +66,7 @@ the current scenario-row $i$ will be followed by a miscellaneous-row $(i + \prcC
 						anchorRow        = i                       ,
 						relOffset        = \prcCommonMiscRowOffset ,
 						oobInstruction   = \locOobInst             ,
-						calleeGas        = \locCalleeGas           ,
+						calleeGas        = \locPrcCalleeGas        ,
 						callDataSize     = \locPrcCds              ,
 						returnAtCapacity = \locPrcRac              ,
 					}

--- a/hub/instruction_handling/call/precompiles/modexp/common.tex
+++ b/hub/instruction_handling/call/precompiles/modexp/common.tex
@@ -564,7 +564,7 @@ These rows follow the same pattern, with the third row also computing \locMaxMbs
 								\setOobInstructionModexpPricing {
 									anchorRow        = i                          ,
 									relOffset        = \prcModexpPricingRowOffset ,
-									calleeGas        = \locCalleeGas              ,
+									calleeGas        = \locPrcCalleeGas           ,
 									returnAtCapacity = \locPrcRac                 ,
 									exponentLog      = \locModexpExponentLog      ,
 									maxMbsBbs        = \locMaxMbsBbs              ,

--- a/hub/instruction_handling/call/precompiles/shorthands.tex
+++ b/hub/instruction_handling/call/precompiles/shorthands.tex
@@ -5,7 +5,7 @@ section~(\ref{hub: instruction handling: call: finishing: cases: prc}).
 \[
 	\left\{ \begin{array}{lclr}
 		\locPrcCallerGas & \define & \scenPrcCurrentlyValidCallerGas _{i} \\
-		\locPrcCallGas   & \define & \scenPrcGasAllowance            _{i} \\
+		\locPrcCalleeGas & \define & \scenPrcGasAllowance            _{i} \\
 		\locPrcReturnGas & \define & \scenPrcGasOwedToCaller         _{i}  & \prediction \\
 		\locPrcCdo       & \define & \scenPrcCdo                     _{i} \\
 		\locPrcCds       & \define & \scenPrcCds                     _{i} \\
@@ -20,12 +20,14 @@ We also remind the reader that \locPrcReturnGas{} is meant to contain
 \[
 	\locPrcReturnGas \equiv
 	\begin{cases}
-		\text{precompile failure:} & 0 \\
-		\text{precompile success:} & \locPrcCallGas - \col{prc\_gas\_cost} \\	
+		\text{precompile failure:} & 0                                       \\
+		\text{precompile success:} & \locPrcCalleeGas - \col{prc\_gas\_cost} \\
 	\end{cases}
 \]
 The precise meaning of ``precompile failure'' and ``precompile success'' is that of 
 section~(\ref{hub: instruction handling: call: precompiles: failures vs. successes}) and
 section~(\ref{hub: instruction handling: call: precompiles: failure classification}).
-Also computing determining failure conditions for precompiles (which in particular involves, but is generally not limited to, computing \col{prc\_gas\_cost} and comparing it to \locPrcCallGas{}) is complex, as is determining the associated cost.
+Also computing determining failure conditions for precompiles
+(which in particular involves, but is generally not limited to, computing \col{prc\_gas\_cost} and comparing it to \locPrcCalleeGas{})
+is complex, as is determining the associated cost.
 Realizing the above requires some preparation. 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches from `locPrcCallGas`/`dup_call_gas` to `locPrcCalleeGas`/`dup_callee_gas` and updates all precompile paths and return-gas formula accordingly.
> 
> - **HUB precompile handling**:
>   - **Shorthand rename/correction**: Introduce `\locPrcCalleeGas` (`dup_callee_gas`) and remove `\locPrcCallGas`.
>   - **Return gas relation**: Update `\locPrcReturnGas` success case to `\locPrcCalleeGas - prc_gas_cost`.
> - **Module updates**:
>   - `precompiles/common/generalities.tex`: Pass `calleeGas = \locPrcCalleeGas` to `\setOobInstructionCommon`.
>   - `precompiles/blake/surviving.tex`: Pass `calleeGas = \locPrcCalleeGas` to `\setOobInstructionBlakeParams`.
>   - `precompiles/modexp/common.tex`: Pass `calleeGas = \locPrcCalleeGas` to `\setOobInstructionModexpPricing`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3af42187a7a4d1215ae04ed45a476b244c4f2b78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->