### PR TITLE
make readme current & minor style fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ todo -->
 Linea's stack is made up of multiple repositories, these include:
 
 - This repo, [linea-specification](https://github.com/Consensys/linea-specification): Specification of the constraint system defining Linea's zkEVM
-- [linea-monorepo](https://github.com/Consensys/linea-monorepo): The main repository for the Linea stack & network. 
+- [linea-monorepo](https://github.com/Consensys/linea-monorepo): The main repository for the Linea stack & network
 > Also maintains a set of Linea-Besu plugins for the sequencer and RPC nodes.
 - [linea-besu](https://github.com/hyperledger/besu/): Besu execution client
 - [linea-tracer](https://github.com/Consensys/linea-tracer): Linea-Besu plugin which produces the traces that the constraint system applies and that serve as inputs to the prover

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ the [Apache 2.0 license](LICENSE).
 
 todo -->
 
-
 ## Looking for the Linea code?
 
 Linea's stack is made up of multiple repositories, these include:
 
 - This repo, [linea-specification](https://github.com/Consensys/linea-specification): Specification of the constraint system defining Linea's zkEVM
-- [linea-monorepo](https://github.com/Consensys/linea-monorepo): The main repository for the Linea stack & network 
-- [linea-besu](https://github.com/Consensys/linea-besu): Fork of Besu to implement the Linea-Besu client
-- [linea-sequencer](https://github.com/Consensys/linea-sequencer): A set of Linea-Besu plugins for the sequencer and RPC nodes
+- [linea-monorepo](https://github.com/Consensys/linea-monorepo): The main repository for the Linea stack & network. 
+> Also maintains a set of Linea-Besu plugins for the sequencer and RPC nodes.
+- [linea-besu](https://github.com/hyperledger/besu/): Besu execution client
 - [linea-tracer](https://github.com/Consensys/linea-tracer): Linea-Besu plugin which produces the traces that the constraint system applies and that serve as inputs to the prover
 - [linea-constraints](https://github.com/Consensys/linea-constraints): Implementation of the constraint system from the specification
+- [linea-specification](https://github.com/Consensys/linea-specification): Specification of the constraint system defining Linea's zkEVM
 
 Linea abstracts away the complexity of this technical architecture to allow developers to:
 
@@ -41,7 +41,7 @@ Linea abstracts away the complexity of this technical architecture to allow deve
 
 Contributions are welcome!
 
-### Guidelines for Non-Code and other Trivial Contributions
+### Guidelines for non-code and other trivial contributions
 Please keep in mind that we do not accept non-code contributions like fixing comments, typos or some other trivial fixes. Although we appreciate the extra help, managing lots of these small contributions is unfeasible, and puts extra pressure in our continuous delivery systems (running all tests, etc). Feel free to open an issue pointing to any of those errors, and we will batch them into a single change.
 
 1. [Create an issue](https://github.com/Consensys/linea-specification/issues).
@@ -60,7 +60,7 @@ Before contributing, ensure you're familiar with:
 
 ### Useful links
 
-- [Linea docs](https://docs.linea.build)
+- [Linea docs](https://docs.linea.build) managed from a [public repo](https://github.com/Consensys/doc.linea)
 - [Linea blog](https://linea.mirror.xyz)
 - [Support](https://support.linea.build)
 - [Discord](https://discord.gg/linea)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ the [Apache 2.0 license](LICENSE).
 
 [Linea](https://linea.build) is a developer-ready layer 2 network scaling Ethereum. It's secured with a zero-knowledge rollup, built on lattice-based cryptography, and powered by [Consensys](https://consensys.io).
 
+Linea is compatible with the execution clients [Besu](https://github.com/hyperledger/besu/) or [Geth](https://github.com/ethereum/go-ethereum). To run a full node, an execution client is paired with [Maru](https://github.com/Consensys/maru).
+
 <!-- ## Get started
 
 todo -->
@@ -24,10 +26,8 @@ Linea's stack is made up of multiple repositories, these include:
 - This repo, [linea-specification](https://github.com/Consensys/linea-specification): Specification of the constraint system defining Linea's zkEVM
 - [linea-monorepo](https://github.com/Consensys/linea-monorepo): The main repository for the Linea stack & network
 > Also maintains a set of Linea-Besu plugins for the sequencer and RPC nodes.
-- [linea-besu](https://github.com/hyperledger/besu/): Besu execution client
 - [linea-tracer](https://github.com/Consensys/linea-tracer): Linea-Besu plugin which produces the traces that the constraint system applies and that serve as inputs to the prover
 - [linea-constraints](https://github.com/Consensys/linea-constraints): Implementation of the constraint system from the specification
-- [linea-specification](https://github.com/Consensys/linea-specification): Specification of the constraint system defining Linea's zkEVM
 
 Linea abstracts away the complexity of this technical architecture to allow developers to:
 


### PR DESCRIPTION
Rmvs links to archived repos to keep readme current
minor style fix and better linking for docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates README to reflect current repos, add Besu/Geth + Maru node compatibility, and make small style/link adjustments.
> 
> - **README** (`README.md`):
>   - **Ecosystem repos**:
>     - Remove archived entries for `linea-besu` and `linea-sequencer`.
>     - Clarify `linea-monorepo` as the main stack repo and note it maintains Linea-Besu plugins.
>   - **Node compatibility**: Add note that Linea works with `Besu` or `Geth`, paired with `Maru` for full nodes.
>   - **Contributing**: Normalize casing in "Guidelines for non-code and other trivial contributions".
>   - **Useful links**: Update "Linea docs" to mention it’s managed from a public repo with link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee21fb63dbeeb3e1231966232e2a0057f0456f00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->