### PR TITLE
Improve GH Actions and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+
+updates:
+  # 1) GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /            # GitHub scans .github/workflows from here
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:00"
+    open-pull-requests-limit: 5
+    assignees: ["OlivierBBB", "letypequividelespoubelles"]
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: "deps(actions)"
+      include: "scope"
+    groups:
+      core-actions-minor-patch:
+        update-types: ["minor", "patch"]
+        patterns:
+          - "actions/*"
+          - "github/*"
+      third-party-actions-minor-patch:
+        update-types: ["minor", "patch"]
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "actions/*"
+          - "github/*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -25,8 +25,10 @@ jobs:
           unzip -q JetBrainsMono.zip -d JetBrainsMono
           sudo mv JetBrainsMono/fonts/ttf/*.ttf /usr/share/fonts/
           rm -rf JetBrainsMono JetBrainsMono.zip
-      - name: Install fontawesome
-        run: sudo apt-get install fonts-font-awesome
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fonts-font-awesome texlive-full
       - name: Install tectonic
         env:
           TECTONIC_VERSION: "0.15.0"
@@ -39,8 +41,6 @@ jobs:
           tar xzf tectonic.tar.gz
           sudo install -m 755 tectonic /usr/local/bin/tectonic
           rm tectonic.tar.gz tectonic
-      - name: Install lualatex
-        run: sudo apt-get update && sudo apt install texlive-full --fix-missing
       - name: Compile Specification
         run: make ospec
       - name: Upload the Specification

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y fonts-font-awesome texlive-full
+          sudo apt-get install -y --fix-missing fonts-font-awesome texlive-full
       - name: Install tectonic
         env:
           TECTONIC_VERSION: "0.15.0"

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -13,7 +13,8 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Install JetBrainsMono
         run: mkdir JetBrainsMono
              && cd JetBrainsMono
@@ -31,7 +32,7 @@ jobs:
       - name: Compile Specification
         run: make ospec
       - name: Upload the Specification
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: specification.pdf
           path: spec/_all_spec.pdf

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -9,6 +9,7 @@ permissions: {} # lock everything by default (least-privilege)
 
 jobs:
   archive-build-spec:
+    name: Build & Upload Specification PDF
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,11 +1,16 @@
 name: Build & Upload the Specification
+
 on:
   push:
     branches: [ main ]
   workflow_dispatch:
 
+permissions: {} # lock everything by default (least-privilege)
+
 jobs:
   archive-build-spec:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -16,18 +16,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install JetBrainsMono
-        run: mkdir JetBrainsMono
-             && cd JetBrainsMono
-              && wget https://download.jetbrains.com/fonts/JetBrainsMono-2.304.zip
-             && unzip JetBrainsMono-2.304.zip
-             && sudo mv fonts/ttf/*.ttf /usr/share/fonts/
-             && cd -
+        env:
+          JETBRAINS_MONO_SHA256: "6f6376c6ed2960ea8a963cd7387ec9d76e3f629125bc33d1fdcd7eb7012f7bbf"
+        run: |
+          wget -q https://download.jetbrains.com/fonts/JetBrainsMono-2.304.zip -O JetBrainsMono.zip
+          echo "${JETBRAINS_MONO_SHA256}  JetBrainsMono.zip" | sha256sum -c
+          unzip -q JetBrainsMono.zip -d JetBrainsMono
+          sudo mv JetBrainsMono/fonts/ttf/*.ttf /usr/share/fonts/
+          rm -rf JetBrainsMono JetBrainsMono.zip
       - name: Install fontawesome
         run: sudo apt-get install fonts-font-awesome
       - name: Install tectonic
-        run: curl --proto '=https' --tlsv1.2 -fsSL https://drop-sh.fullyjustified.net |sh
+        env:
+          TECTONIC_VERSION: "0.15.0"
+          TECTONIC_SHA256: "875fbbc9ab48560d7776088c608e0beee49197b57ab4a2f6c5385b2c661c842f"
+        run: |
+          curl --proto '=https' --tlsv1.2 -fsSL \
+            "https://github.com/tectonic-typesetting/tectonic/releases/download/tectonic%40${TECTONIC_VERSION}/tectonic-${TECTONIC_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            -o tectonic.tar.gz
+          echo "${TECTONIC_SHA256}  tectonic.tar.gz" | sha256sum -c
+          tar xzf tectonic.tar.gz
+          sudo install -m 755 tectonic /usr/local/bin/tectonic
+          rm tectonic.tar.gz tectonic
       - name: Install lualatex
-        # run: sudo apt-get install texlive-latex-base && sudo apt install texlive-luatex && sudo apt-get install texlive-latex-extra
         run: sudo apt-get update && sudo apt install texlive-full --fix-missing
       - name: Compile Specification
         run: make ospec

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -16,11 +16,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install JetBrainsMono
         env:
           JETBRAINS_MONO_SHA256: "6f6376c6ed2960ea8a963cd7387ec9d76e3f629125bc33d1fdcd7eb7012f7bbf"
         run: |
-          wget -q https://download.jetbrains.com/fonts/JetBrainsMono-2.304.zip -O JetBrainsMono.zip
+          wget -q --secure-protocol=TLSv1_2 https://download.jetbrains.com/fonts/JetBrainsMono-2.304.zip -O JetBrainsMono.zip
           echo "${JETBRAINS_MONO_SHA256}  JetBrainsMono.zip" | sha256sum -c
           unzip -q JetBrainsMono.zip -d JetBrainsMono
           sudo mv JetBrainsMono/fonts/ttf/*.ttf /usr/share/fonts/

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -15,6 +15,8 @@ on:
         required: false
   workflow_dispatch:
 
+permissions: {} # lock everything by default (least-privilege)
+
 jobs:
   security-scan:
     uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@v2

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ recompile-%: lua_build
 	cd $* && tectonic -X compile _all_$*.tex
 
 buildOnGithub-%: lua_build
-	cd $* && ../tectonic -X compile _all_$*.tex
+	cd $* && tectonic -X compile _all_$*.tex
 
 alu:             view-alu
 blake:           view-blake_data


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to CI/configuration and should not affect runtime behavior; main risk is CI failures due to updated action versions or stricter permissions/tool install steps.
> 
> **Overview**
> Adds a new `.github/dependabot.yml` to enable weekly Dependabot updates for GitHub Actions, with grouping/labeling and PR limits.
> 
> Hardens CI workflows by defaulting `permissions` to none and granting job-level minimal access, updates `actions/checkout` and `actions/upload-artifact` to `@v6`, and makes the spec build more reproducible by verifying SHA256 for downloaded font/`tectonic` artifacts and installing required system packages in a single step.
> 
> Updates `Makefile` `buildOnGithub-%` to invoke system `tectonic` (matching the workflow install) instead of a repo-local binary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ebab0fbc9cf0a3efe37968745a61e9513a907d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->