### PR TITLE
Update README with archiving notice and new link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> **This repository has been archived and is no longer actively maintained.**
+> The content has been moved to [**Consensys/linea-monorepo**](https://github.com/Consensys/linea-monorepo).
+> Please refer to that repository for the latest implementation of the Linea specification.
+
 # Linea zkEVM specification
 
 This repository hosts the specification of the constraint system underlying Linea's zkEVM.


### PR DESCRIPTION
Added a warning about repository archiving and redirection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds an archive banner and redirects readers to the maintained repository.
> 
> **Overview**
> Adds a top-of-README `WARNING` banner stating the repository is archived and no longer maintained, and directs readers to `Consensys/linea-monorepo` for the latest Linea specification implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52f6e0c0483ddb1fc0f053018c2dc5c68fca7729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->